### PR TITLE
Added unit test for JsonSplitUDF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <apache.hadoop.version>0.20.2</apache.hadoop.version>
         <apache.hbase.version>0.92.1</apache.hbase.version>
         <apache.hive.version>0.10.0</apache.hive.version>
+        <codehaus.jackson.version>1.8.8</codehaus.jackson.version>
     </properties>
 
     <build>
@@ -216,6 +217,29 @@
             <version>2.3.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+            <version>${codehaus.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
+            <version>${codehaus.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-xc</artifactId>
+            <version>${codehaus.jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>${codehaus.jackson.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/brickhouse/udf/json/JsonSplitUDFTest.java
+++ b/src/test/java/brickhouse/udf/json/JsonSplitUDFTest.java
@@ -1,0 +1,67 @@
+package brickhouse.udf.json;
+
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author andrey.myatlyuk@lithium.com
+ */
+public class JsonSplitUDFTest {
+
+	private JsonSplitUDF udf;
+
+	@Before
+	public void before() {
+		udf = new JsonSplitUDF();
+	}
+
+	@Test
+	public void testEvaluate() throws Exception {
+		ObjectInspector stringOi = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+		StandardListObjectInspector resultOi = (StandardListObjectInspector) udf.initialize(new ObjectInspector[]{stringOi});
+
+		String value = "[\"a\", \"b\"]";
+
+		Object result = udf.evaluate(new GenericUDF.DeferredObject[]{new GenericUDF.DeferredJavaObject(value)});
+		assertEquals(2, resultOi.getList(result).size());
+	}
+
+	@Test
+	public void testEvaluateWithEmptyList() throws Exception {
+		ObjectInspector stringOi = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+		StandardListObjectInspector resultOi = (StandardListObjectInspector) udf.initialize(new ObjectInspector[]{stringOi});
+
+		String value = "[]";
+
+		Object result = udf.evaluate(new GenericUDF.DeferredObject[]{new GenericUDF.DeferredJavaObject(value)});
+		assertTrue(resultOi.getList(result).isEmpty());
+	}
+
+	@Test(expected = HiveException.class)
+	public void testEvaluateWithEmptyString() throws Exception {
+		ObjectInspector stringOi = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+		udf.initialize(new ObjectInspector[]{stringOi});
+
+		String value = "";
+
+		udf.evaluate(new GenericUDF.DeferredObject[]{new GenericUDF.DeferredJavaObject(value)});
+	}
+
+	@Test
+	public void testEvaluateWithNull() throws Exception {
+		ObjectInspector stringOi = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+		StandardListObjectInspector resultOi = (StandardListObjectInspector) udf.initialize(new ObjectInspector[]{stringOi});
+
+		Object result = udf.evaluate(new GenericUDF.DeferredObject[]{new GenericUDF.DeferredJavaObject(null)});
+		assertNull(resultOi.getList(result));
+	}
+}


### PR DESCRIPTION
I had to update jackson libraries because of higher a version in hive-exec, and it requires `jackson-core-asl` classes with version 1.7+ at runtime

    [INFO] +- org.apache.hive:hive-exec:jar:0.10.0:compile
    [INFO] |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.8.8:compile

while hbase is pulling 1.5.5

    [INFO] +- org.apache.hbase:hbase:jar:0.92.1:compile
    [INFO] |  +- org.codehaus.jackson:jackson-core-asl:jar:1.5.5:compile
    [INFO] |  +- org.codehaus.jackson:jackson-jaxrs:jar:1.5.5:compile
    [INFO] |  +- org.codehaus.jackson:jackson-xc:jar:1.5.5:compile

Although only `jackson-core-asl` had to be updated, I decided it is better to keep them all in sync.