### PR TITLE
Have json_map return null if input is null

### DIFF
--- a/src/main/java/brickhouse/udf/json/JsonMapUDF.java
+++ b/src/main/java/brickhouse/udf/json/JsonMapUDF.java
@@ -56,8 +56,7 @@ public class JsonMapUDF extends GenericUDF {
     private InspectorHandle inspHandle;
 
     @Override
-    public ObjectInspector initialize(ObjectInspector[] arguments)
-            throws UDFArgumentException {
+    public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
         if(arguments.length != 1 && arguments.length != 2) {
             throw new UDFArgumentException("Usage : json_map( jsonstring, optional typestring ) ");
         }
@@ -110,11 +109,15 @@ public class JsonMapUDF extends GenericUDF {
     @Override
     public Object evaluate(DeferredObject[] arguments) throws HiveException {
         try {
-            String jsonString =  this.stringInspector.getPrimitiveJavaObject(arguments[0].get());
+            if (null == arguments[0].get()) {
+                return null;
+            }
+
+            String jsonString = this.stringInspector.getPrimitiveJavaObject(arguments[0].get());
 
             //// Logic is the same as "from_json"
             ObjectMapper om = new ObjectMapper();
-            JsonNode jsonNode = om.readTree( jsonString);
+            JsonNode jsonNode = om.readTree(jsonString);
             return inspHandle.parseJson(jsonNode);
 
         } catch (JsonProcessingException e) {

--- a/src/main/java/brickhouse/udf/json/JsonMapUDF.java
+++ b/src/main/java/brickhouse/udf/json/JsonMapUDF.java
@@ -44,89 +44,89 @@ import brickhouse.udf.json.InspectorHandle.InspectorHandleFactory;
 
 /**
  *  Given a JSON String containing a map with values of all the same type,
- *    return a Hive map of key-value pairs 
+ *    return a Hive map of key-value pairs
  *
  */
 
 @Description(name="json_map",
-value = "_FUNC_(json) - Returns a map of key-value pairs from a JSON string" 
+value = "_FUNC_(json) - Returns a map of key-value pairs from a JSON string"
 )
 public class JsonMapUDF extends GenericUDF {
-	private StringObjectInspector stringInspector;
-	private InspectorHandle inspHandle;
+    private StringObjectInspector stringInspector;
+    private InspectorHandle inspHandle;
 
-	@Override
-	public ObjectInspector initialize(ObjectInspector[] arguments)
-			throws UDFArgumentException {
-		if(arguments.length != 1 && arguments.length != 2) {
-			throw new UDFArgumentException("Usage : json_map( jsonstring, optional typestring ) ");
-		}
-		if(!arguments[0].getCategory().equals( Category.PRIMITIVE)
-		        || ((PrimitiveObjectInspector)arguments[0]).getPrimitiveCategory() != PrimitiveCategory.STRING) {
-			throw new UDFArgumentException("Usage : json_map( jsonstring, optional typestring) ");
-		}
-		
-		stringInspector = (StringObjectInspector) arguments[0];
-		
-		if( arguments.length > 1) {
-		    if(!arguments[1].getCategory().equals( Category.PRIMITIVE)
-		        && ((PrimitiveObjectInspector)arguments[1]).getPrimitiveCategory() != PrimitiveCategory.STRING) {
-		        throw new UDFArgumentException("Usage : json_map( jsonstring, optional typestring) ");
-		    }
-		    if(!(arguments[1] instanceof ConstantObjectInspector)) {
-		        throw new UDFArgumentException("json_map( jsonstring, typestring ) : typestring must be a constant");
-		    }
-		    ConstantObjectInspector constInsp = (ConstantObjectInspector) arguments[1];
-		    String typeStr = ((Text) constInsp.getWritableConstantValue()).toString();
-		    
-		    String[] types = typeStr.split(",");
-		    if( types.length != 2) {
-		        throw new UDFArgumentException(" typestring must be of the form <keytype>,<valuetype>");
-		    }
-		    TypeInfo keyType = TypeInfoUtils.getTypeInfoFromTypeString(types[0]);
-		    TypeInfo valType = TypeInfoUtils.getTypeInfoFromTypeString(types[1]);
-		    
-		    ObjectInspector keyInsp = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(keyType);
-		    ObjectInspector valInsp = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(valType);
-		    
-		    MapObjectInspector mapInsp = ObjectInspectorFactory.getStandardMapObjectInspector(keyInsp, valInsp);
-		    
-		    inspHandle = InspectorHandleFactory.GenerateInspectorHandle(mapInsp);
-		    
-		    return inspHandle.getReturnType();
-		    
-		} else {
-		    ObjectInspector keyInsp = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
-		    ObjectInspector valueInsp = PrimitiveObjectInspectorFactory.javaDoubleObjectInspector; /// XXX Make value type configurable somehow
-		
-		    MapObjectInspector mapInsp = ObjectInspectorFactory.getStandardMapObjectInspector(keyInsp, valueInsp);
-		    
-		    inspHandle = InspectorHandleFactory.GenerateInspectorHandle(mapInsp);
-		    
-		    return inspHandle.getReturnType();
-		}
-	}
+    @Override
+    public ObjectInspector initialize(ObjectInspector[] arguments)
+            throws UDFArgumentException {
+        if(arguments.length != 1 && arguments.length != 2) {
+            throw new UDFArgumentException("Usage : json_map( jsonstring, optional typestring ) ");
+        }
+        if(!arguments[0].getCategory().equals( Category.PRIMITIVE)
+                || ((PrimitiveObjectInspector)arguments[0]).getPrimitiveCategory() != PrimitiveCategory.STRING) {
+            throw new UDFArgumentException("Usage : json_map( jsonstring, optional typestring) ");
+        }
 
-	@Override
-	public Object evaluate(DeferredObject[] arguments) throws HiveException {
-		try {
-		    String jsonString =  this.stringInspector.getPrimitiveJavaObject(arguments[0].get());
-			
-		    //// Logic is the same as "from_json"
+        stringInspector = (StringObjectInspector) arguments[0];
+
+        if( arguments.length > 1) {
+            if(!arguments[1].getCategory().equals( Category.PRIMITIVE)
+                && ((PrimitiveObjectInspector)arguments[1]).getPrimitiveCategory() != PrimitiveCategory.STRING) {
+                throw new UDFArgumentException("Usage : json_map( jsonstring, optional typestring) ");
+            }
+            if(!(arguments[1] instanceof ConstantObjectInspector)) {
+                throw new UDFArgumentException("json_map( jsonstring, typestring ) : typestring must be a constant");
+            }
+            ConstantObjectInspector constInsp = (ConstantObjectInspector) arguments[1];
+            String typeStr = ((Text) constInsp.getWritableConstantValue()).toString();
+
+            String[] types = typeStr.split(",");
+            if( types.length != 2) {
+                throw new UDFArgumentException(" typestring must be of the form <keytype>,<valuetype>");
+            }
+            TypeInfo keyType = TypeInfoUtils.getTypeInfoFromTypeString(types[0]);
+            TypeInfo valType = TypeInfoUtils.getTypeInfoFromTypeString(types[1]);
+
+            ObjectInspector keyInsp = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(keyType);
+            ObjectInspector valInsp = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(valType);
+
+            MapObjectInspector mapInsp = ObjectInspectorFactory.getStandardMapObjectInspector(keyInsp, valInsp);
+
+            inspHandle = InspectorHandleFactory.GenerateInspectorHandle(mapInsp);
+
+            return inspHandle.getReturnType();
+
+        } else {
+            ObjectInspector keyInsp = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+            ObjectInspector valueInsp = PrimitiveObjectInspectorFactory.javaDoubleObjectInspector; /// XXX Make value type configurable somehow
+
+            MapObjectInspector mapInsp = ObjectInspectorFactory.getStandardMapObjectInspector(keyInsp, valueInsp);
+
+            inspHandle = InspectorHandleFactory.GenerateInspectorHandle(mapInsp);
+
+            return inspHandle.getReturnType();
+        }
+    }
+
+    @Override
+    public Object evaluate(DeferredObject[] arguments) throws HiveException {
+        try {
+            String jsonString =  this.stringInspector.getPrimitiveJavaObject(arguments[0].get());
+
+            //// Logic is the same as "from_json"
             ObjectMapper om = new ObjectMapper();
             JsonNode jsonNode = om.readTree( jsonString);
             return inspHandle.parseJson(jsonNode);
-            
-		} catch (JsonProcessingException e) {
-			throw new HiveException(e);
-		} catch (IOException e) {
-			throw new HiveException(e);
-		}
-	}
 
-	@Override
-	public String getDisplayString(String[] children) {
-		return "json_map( " + children[0] + " )";
-	}
+        } catch (JsonProcessingException e) {
+            throw new HiveException(e);
+        } catch (IOException e) {
+            throw new HiveException(e);
+        }
+    }
+
+    @Override
+    public String getDisplayString(String[] children) {
+        return "json_map( " + children[0] + " )";
+    }
 
 }

--- a/src/test/java/brickhouse/udf/json/JsonUDFTest.java
+++ b/src/test/java/brickhouse/udf/json/JsonUDFTest.java
@@ -13,6 +13,10 @@ import org.junit.Test;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.*;
+import brickhouse.udf.json.*;
+
 public class JsonUDFTest {
 
 	@Test
@@ -34,5 +38,12 @@ public class JsonUDFTest {
 		
 		Assert.assertEquals( "this_text_is_in_camel_case", under);
 	}
-	
+
+	@Test
+	public void testJsonMapHandlesNulls() throws HiveException {
+		JsonMapUDF cut = new JsonMapUDF();
+		Object result = cut.evaluate( new DeferredObject[]{ new DeferredJavaObject(null) } );
+		Assert.assertNull( result );
+	}
+
 }


### PR DESCRIPTION
When doing queries on columns that are either null or contain JSON data it's useful to have `json_map` simply return null and skip the record rather then thrown an exception. This change does that and adds a test for it.