### PR TITLE
Updated HyperLogLog version, minor changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <apache.hadoop.version>0.20.2</apache.hadoop.version>
-        <apache.hbase.version>0.92.1</apache.hbase.version>
-        <apache.hive.version>0.10.0</apache.hive.version>
+        <apache.hadoop.version>2.5.0-mr1-cdh5.2.1</apache.hadoop.version>
+        <apache.hbase.version>1.0.0-cdh5.2.1</apache.hbase.version>
+        <apache.hive.version>0.13.1-cdh5.2.1</apache.hive.version>
         <codehaus.jackson.version>1.8.8</codehaus.jackson.version>
     </properties>
 
@@ -155,6 +155,12 @@
     </reporting>
 
     <dependencies>
+        
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
 
         <!-- Hive -->
         <dependency>
@@ -190,14 +196,8 @@
 
         <dependency>
             <groupId>org.apache.hbase</groupId>
-            <artifactId>hbase</artifactId>
+            <artifactId>hbase-client</artifactId>
             <version>${apache.hbase.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
         </dependency>
 
         <dependency>
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>com.clearspring.analytics</groupId>
             <artifactId>stream</artifactId>
-            <version>2.3.0</version>
+            <version>2.7.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/brickhouse/udf/hll/HLLBuffer.java
+++ b/src/main/java/brickhouse/udf/hll/HLLBuffer.java
@@ -68,7 +68,7 @@ public class HLLBuffer implements AggregationBuffer {
             precision = (int) Math.ceil(Math.log(other.sizeof()) / Math.log(2.0));
             LOG.debug("precision set to: " + precision);
         } else {
-            hll.merge(other);
+            hll = hll.merge(other);
         }
     }
 

--- a/src/main/java/brickhouse/udf/hll/HyperLogLogUDAF.java
+++ b/src/main/java/brickhouse/udf/hll/HyperLogLogUDAF.java
@@ -50,7 +50,7 @@ public class HyperLogLogUDAF extends AbstractGenericUDAFResolver {
     private static final Logger LOG = Logger.getLogger(HyperLogLogUDAF.class);
     static final int DEFAULT_PRECISION = 6;
     static final int MIN_PRECISION = 4;
-    static final int MAX_PRECISION = 16;
+    static final int MAX_PRECISION = 32;
 
     @SuppressWarnings("deprecation")
     @Override

--- a/src/main/java/brickhouse/udf/hll/UnionHyperLogLogUDAF.java
+++ b/src/main/java/brickhouse/udf/hll/UnionHyperLogLogUDAF.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.log4j.Logger;
 
 /**
- * Aggregate multiple HyerLogLog structures together.
+ * Aggregate multiple HyperLogLog structures together.
  */
 
 @Description(name = "union_hyperloglog",


### PR DESCRIPTION
Main change is updating HLLBuffer line " hll.merge(other);" to "hll = hll.merge(other);", this is necessary because in the new versions the merge function is immutable and returns a new HyperLogLogPlus object. This prevents a bug when using the new version where the HLLP is never updated during aggregation and only returns the cardinality of the first byte array. 

Changed dependency for new clearspring HyperLogLogPlus
Updated HLLBuffer to be comaptible with new merge function (new
merge is an immutable function)
Updated max precision to be 32 (no reason to limit precision)
Corrected typo in UnionHyperLogLogUDAF