### PR TITLE
Hive 1.2 support:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,14 +40,51 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <apache.hadoop.version>0.20.2</apache.hadoop.version>
+        <apache.hadoop.version>1.2.1</apache.hadoop.version>
         <apache.hbase.version>0.92.1</apache.hbase.version>
-        <apache.hive.version>0.10.0</apache.hive.version>
+        <apache.hive.version>1.2.0</apache.hive.version>
         <codehaus.jackson.version>1.8.8</codehaus.jackson.version>
     </properties>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>com.example.shaded.com.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.thirdparty</pattern>
+                                    <shadedPattern>com.example.shaded.com.google.thirdparty</shadedPattern>
+                                </relocation>
+                            </relocations>
+                           <filters>
+                               <filter>
+                                   <artifact>*:*</artifact>
+                                   <excludes>
+                                       <exclude>META-INF/*.SF</exclude>
+                                       <exclude>META-INF/*.DSA</exclude>
+                                       <exclude>META-INF/*.RSA</exclude>
+                                   </excludes>
+                                </filter>
+                            </filters>
+                            <minimizeJar>true</minimizeJar>
+                        </configuration>
+                      </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
@@ -155,6 +192,12 @@
     </reporting>
 
     <dependencies>
+        <!-- Guava order matters so we put it on top. -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
 
         <!-- Hive -->
         <dependency>
@@ -192,12 +235,6 @@
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase</artifactId>
             <version>${apache.hbase.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
* Bumped Hive dependency to 1.2.0
* Bumped Hadoop dependency to 1.2.1 (Several CNF exceptions without this move)
* Moved Guava to the top of dependencies
* Shaded the JAR to prevent Guava conflicts. 3 functions will fail with the unshaded JAR (hash_md5 is one of them)