### PR TITLE
add missing TimestampObjectInspector to handler

### DIFF
--- a/src/main/java/brickhouse/udf/json/ToJsonUDF.java
+++ b/src/main/java/brickhouse/udf/json/ToJsonUDF.java
@@ -409,6 +409,8 @@ public class ToJsonUDF extends GenericUDF {
                 return new ByteInspectorHandle((ByteObjectInspector) primInsp);
             } else if (primCat == PrimitiveCategory.BINARY) {
                 return new BinaryInspectorHandle((BinaryObjectInspector) primInsp);
+            } else if (primCat == PrimitiveCategory.TIMESTAMP) {
+                return new TimestampInspectorHandle((TimestampObjectInspector) primInsp);
             }
 
 


### PR DESCRIPTION
See Issue #124

ToJsonUDF was crashing when trying to convert convert timestamps. Turns out it was because the Handler was missing from the InspectorHandler if/else logic

will close PR https://github.com/klout/brickhouse/pull/125 which contained another unneeded commit