### PR TITLE
Created the CollectDistinct UDAF

### DIFF
--- a/src/main/java/brickhouse/udf/collect/CollectDistinctUDAF.java
+++ b/src/main/java/brickhouse/udf/collect/CollectDistinctUDAF.java
@@ -1,0 +1,156 @@
+package brickhouse.udf.collect;
+/**
+ * Copyright 2012 Klout, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+
+/**
+ * Similar to Ruby collect, 
+ *   return an array with all the values
+ */
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+
+@Description(name = "collect_distinct",
+        value = "_FUNC_(x) - Returns an array of distinct the elements in the aggregation group "
+)
+public class CollectDistinctUDAF extends AbstractGenericUDAFResolver {
+
+
+    @Override
+    public GenericUDAFEvaluator getEvaluator(TypeInfo[] parameters)
+            throws SemanticException {
+        // TODO Auto-generated method stub
+        if (parameters.length != 1) {
+            throw new UDFArgumentTypeException(parameters.length - 1,
+                    "One argument is expected to return an Array.");
+        }
+        return new SetCollectUDAFEvaluator();
+        
+    }
+
+    public static class SetCollectUDAFEvaluator extends GenericUDAFEvaluator {
+        // For PARTIAL1 and COMPLETE: ObjectInspectors for original data
+        private ObjectInspector inputOI;
+        // For PARTIAL2 and FINAL: ObjectInspectors for partial aggregations (list
+        // of objs)
+        private StandardListObjectInspector loi;
+        private StandardListObjectInspector internalMergeOI;
+
+
+        static class ArrayAggBuffer implements AggregationBuffer {
+            Set collectArray = new HashSet();
+        }
+
+        public ObjectInspector init(Mode m, ObjectInspector[] parameters)
+                throws HiveException {
+            super.init(m, parameters);
+            // init output object inspectors
+            // The output of a partial aggregation is a list
+            if (m == Mode.PARTIAL1) {
+                inputOI = parameters[0];
+                return ObjectInspectorFactory
+                        .getStandardListObjectInspector(ObjectInspectorUtils
+                                .getStandardObjectInspector(inputOI));
+            } else {
+                if (!(parameters[0] instanceof StandardListObjectInspector)) {
+                    //no map aggregation.
+                    inputOI = ObjectInspectorUtils
+                            .getStandardObjectInspector(parameters[0]);
+                    return (StandardListObjectInspector) ObjectInspectorFactory
+                            .getStandardListObjectInspector(inputOI);
+                } else {
+                    internalMergeOI = (StandardListObjectInspector) parameters[0];
+                    inputOI = internalMergeOI.getListElementObjectInspector();
+                    loi = (StandardListObjectInspector) ObjectInspectorUtils.getStandardObjectInspector(internalMergeOI);
+                    return loi;
+                }
+            }
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() throws HiveException {
+            AggregationBuffer buff = new ArrayAggBuffer();
+            reset(buff);
+            return buff;
+        }
+
+        @Override
+        public void iterate(AggregationBuffer agg, Object[] parameters)
+                throws HiveException {
+            Object p = parameters[0];
+
+            if (p != null) {
+                ArrayAggBuffer myagg = (ArrayAggBuffer) agg;
+                putIntoSet(p, myagg);
+            }
+        }
+
+        @Override
+        public void merge(AggregationBuffer agg, Object partial)
+                throws HiveException {
+            ArrayAggBuffer myagg = (ArrayAggBuffer) agg;
+            ArrayList<Object> partialResult = (ArrayList<Object>) internalMergeOI.getList(partial);
+            for (Object i : partialResult) {
+                putIntoSet(i, myagg);
+            }
+        }
+
+        @Override
+        public void reset(AggregationBuffer buff) throws HiveException {
+            ArrayAggBuffer arrayBuff = (ArrayAggBuffer) buff;
+            arrayBuff.collectArray = new HashSet();
+        }
+
+        @Override
+        public Object terminate(AggregationBuffer agg) throws HiveException {
+            ArrayAggBuffer myagg = (ArrayAggBuffer) agg;
+            ArrayList<Object> ret = new ArrayList<Object>(myagg.collectArray.size());
+            ret.addAll(myagg.collectArray);
+            return ret;
+
+        }
+
+        private void putIntoSet(Object p, ArrayAggBuffer myagg) {
+            Object pCopy = ObjectInspectorUtils.copyToStandardObject(p,
+                    this.inputOI);
+            myagg.collectArray.add(pCopy);
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer agg) throws HiveException {
+            ArrayAggBuffer myagg = (ArrayAggBuffer) agg;
+            ArrayList<Object> ret = new ArrayList<Object>(myagg.collectArray.size());
+            ret.addAll(myagg.collectArray);
+            return ret;
+        }
+    }
+}

--- a/src/main/resources/brickhouse.hql
+++ b/src/main/resources/brickhouse.hql
@@ -8,6 +8,7 @@ CREATE TEMPORARY FUNCTION intersect_array AS 'brickhouse.udf.collect.ArrayInters
 
 CREATE TEMPORARY FUNCTION array_flatten AS 'brickhouse.udf.collect.ArrayFlattenUDF';
 CREATE TEMPORARY FUNCTION collect AS 'brickhouse.udf.collect.CollectUDAF';
+CREATE TEMPORARY FUNCTION collect_distinct AS 'brickhouse.udf.collect.CollectDistinctUDAF';
 
 CREATE TEMPORARY FUNCTION collect_max AS 'brickhouse.udf.collect.CollectMaxUDAF';
 CREATE TEMPORARY FUNCTION collect_merge_max AS 'brickhouse.udf.collect.CollectMergeMaxUDAF';

--- a/src/test/java/brickhouse/udf/collect/CollectDistinctUDFTest.java
+++ b/src/test/java/brickhouse/udf/collect/CollectDistinctUDFTest.java
@@ -1,0 +1,122 @@
+package brickhouse.udf.collect;
+
+import brickhouse.udf.collect.CollectDistinctUDAF.SetCollectUDAFEvaluator;
+import brickhouse.udf.collect.CollectMaxUDAF.MapCollectMaxUDAFEvaluator;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator.Mode;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableIntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableStringObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CollectDistinctUDFTest {
+
+	private CollectDistinctUDAF udf;
+
+	@Before
+	public void before() {
+		udf = new CollectDistinctUDAF();
+	}
+
+	@Test(expected = UDFArgumentTypeException.class)
+	public void testGetEvaluatorNoArg() throws SemanticException {
+		udf.getEvaluator(new StructTypeInfo[0]);
+	}
+
+	@Test(expected = UDFArgumentTypeException.class)
+	public void testGetEvaluatorTwoArg() throws SemanticException {
+		List<String> structFieldNames = new ArrayList<String>();
+		structFieldNames.add("field1");
+		structFieldNames.add("field2");
+
+		List<ObjectInspector> objectInspectors = new ArrayList<ObjectInspector>();
+		objectInspectors
+				.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+		objectInspectors
+				.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+
+		StructTypeInfo structTypeInfo = (StructTypeInfo) TypeInfoUtils
+				.getTypeInfoFromObjectInspector(ObjectInspectorFactory
+						.getStandardStructObjectInspector(structFieldNames,
+								objectInspectors));
+
+		List<String> structFieldNames2 = new ArrayList<String>();
+		structFieldNames2.add("field1");
+		structFieldNames2.add("field2");
+
+		List<ObjectInspector> objectInspectors2 = new ArrayList<ObjectInspector>();
+		objectInspectors2
+				.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+		objectInspectors2
+				.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+
+		StructTypeInfo structTypeInfo2 = (StructTypeInfo) TypeInfoUtils
+				.getTypeInfoFromObjectInspector(ObjectInspectorFactory
+						.getStandardStructObjectInspector(structFieldNames2,
+								objectInspectors2));
+
+		udf.getEvaluator(new StructTypeInfo[] { structTypeInfo, structTypeInfo2 });
+	}
+
+	@Test
+	public void testInitializeWithOneArguments() throws SemanticException {
+		List<String> structFieldNames = new ArrayList<String>();
+		structFieldNames.add("field1");
+		structFieldNames.add("field2");
+
+		List<ObjectInspector> objectInspectors = new ArrayList<ObjectInspector>();
+		objectInspectors
+				.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+		objectInspectors
+				.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+
+		StructTypeInfo structTypeInfo = (StructTypeInfo) TypeInfoUtils
+				.getTypeInfoFromObjectInspector(ObjectInspectorFactory
+						.getStandardStructObjectInspector(structFieldNames,
+								objectInspectors));
+		udf.getEvaluator(new StructTypeInfo[] { structTypeInfo });
+	}
+
+	@Test
+	public void testInit() throws HiveException {
+
+		SetCollectUDAFEvaluator maxEval = new SetCollectUDAFEvaluator();
+
+		List<String> fieldNames = new ArrayList<String>();
+		fieldNames.add("field1");
+		fieldNames.add("field2");
+
+		List<ObjectInspector> objectInspectors = new ArrayList<ObjectInspector>();
+		objectInspectors
+				.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+		objectInspectors
+				.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+		StructObjectInspector keyOI = ObjectInspectorFactory
+				.getStandardStructObjectInspector(fieldNames, objectInspectors);
+		// WritableIntObjectInspector valOI = (WritableIntObjectInspector)
+		// PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(PrimitiveCategory.INT);
+
+		maxEval.init(Mode.PARTIAL1, new ObjectInspector[] { keyOI });
+	}
+}


### PR DESCRIPTION
Fix for issue #139 
Users can use collect_distinct when they was unique values in the array. It also helps to avoid duplication when more than one collect is used in a hive select statement (more than one columns need to be collected).